### PR TITLE
Fixup to use GlobalVariableExpression rather than GlobalVariable

### DIFF
--- a/lib/bytesflops/bytesflops.h
+++ b/lib/bytesflops/bytesflops.h
@@ -159,7 +159,7 @@ namespace bytesflops_pass {
     InternalSymbolInfo(Value* value, string defn_loc);
 
     // Construct an InternalSymbolInfo directly from a DIGlobalVariable..
-    InternalSymbolInfo(DIGlobalVariable& var, string defn_loc);
+    InternalSymbolInfo(DIGlobalVariableExpression& var, string defn_loc);
 
     // Construct an InternalSymbolInfo from a Function.
     InternalSymbolInfo(Function* funcptr);

--- a/lib/bytesflops/init.cpp
+++ b/lib/bytesflops/init.cpp
@@ -136,11 +136,11 @@ namespace bytesflops_pass {
     for (auto gv_iter = gv_list.begin(); gv_iter != gv_list.end(); gv_iter++) {
       // Acquire debug information for one global variable.
       GlobalVariable& gv_var = *gv_iter;
-      SmallVector<DIGlobalVariable*, 1> gvs;
+      SmallVector<DIGlobalVariableExpression*,1> gvs;
       gv_var.getDebugInfo(gvs);
       if (gvs.size() == 0)
         continue;
-      DIGlobalVariable* gv = gvs[0];
+      DIGlobalVariableExpression* gv = gvs[0];
       Type* gv_type  = gv_var.getType();   // Data type
       if (gv_type->isPointerTy())
         gv_type = gv_type->getPointerElementType();

--- a/lib/bytesflops/instrument.cpp
+++ b/lib/bytesflops/instrument.cpp
@@ -10,6 +10,8 @@
 #include <iostream>
 #include "bytesflops.h"
 
+#include <llvm/IR/Attributes.h>
+
 namespace bytesflops_pass {
 
   const int BytesFlops::CLEAR_LOADS          =   1;
@@ -63,7 +65,7 @@ namespace bytesflops_pass {
     void_12->setCallingConv(CallingConv::C);
     void_12->setTailCall(false);
     mark_as_byfl(void_12);
-    AttributeSet void_12_PAL;
+    llvm::AttributeList void_12_PAL;
     void_12->setAttributes(void_12_PAL);
 
     ReturnInst::Create(ctx, ctor_bb);

--- a/lib/bytesflops/symbolinfo.cpp
+++ b/lib/bytesflops/symbolinfo.cpp
@@ -168,15 +168,15 @@ InternalSymbolInfo::InternalSymbolInfo(Value* value, string defn_loc)
 }
 
 // Construct an InternalSymbolInfo from a DIGlobalVariable..
-InternalSymbolInfo::InternalSymbolInfo(DIGlobalVariable& var, string defn_loc) {
+InternalSymbolInfo::InternalSymbolInfo(DIGlobalVariableExpression& var, string defn_loc) {
   if (prng == nullptr)
     prng = new MersenneTwister("InternalSymbolInfo Global");  // Arbitrary salt
   ID = prng->next();
   origin = defn_loc;
-  symbol = var.getName().str();
+  symbol = var.getVariable()->getName().str();
   function = "*GLOBAL*";
-  file = full_file_path(var.getDirectory(), var.getFilename());
-  line = var.getLine();
+  file = full_file_path(var.getVariable()->getDirectory(), var.getVariable()->getFilename());
+  line = var.getVariable()->getLine();
 }
 
 // Construct an InternalSymbolInfo from a Function.


### PR DESCRIPTION
Hey, I probably would not merge this PR as is, but this is what I did to get Byfl building on a fairly recent tip of trunk Clang, I was getting errors about "AttributeSet" not existing and then "GlobalVariable" things causing issues, now that Set is a List, and that Variable is a VariableExpression. Call it an issue with a candidate fix, though if it works for you feel free to merge it

edit with an aside: I also just looked at bf-clang, and may look at adapting this for my own Clang plugins, this is really nifty stuff.